### PR TITLE
Disable cloning of submodule cloning by default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "test/cbmc/aws-templates-for-cbmc-proofs"]
 	path = test/cbmc/aws-templates-for-cbmc-proofs
 	url = https://github.com/awslabs/aws-templates-for-cbmc-proofs.git
+	update = none
 [submodule "test/cbmc/litani"]
 	path = test/cbmc/litani
 	url = https://github.com/awslabs/aws-build-accumulator
+	update = none
 [submodule "test/unit-test/Unity"]
 	path = test/unit-test/Unity
 	url = https://github.com/ThrowTheSwitch/Unity
+	update = none

--- a/test/unit-test/unity_build.cmake
+++ b/test/unit-test/unity_build.cmake
@@ -3,7 +3,7 @@ macro( clone_unity )
     find_package( Git REQUIRED )
     message( "Cloning Unity submodule." )
     execute_process( COMMAND rm -rf ${UNITY_DIR}
-                     COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive ${UNITY_DIR}
+                     COMMAND ${GIT_EXECUTABLE} submodule update --checkout --init --recursive ${UNITY_DIR}
                      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                      RESULT_VARIABLE UNITY_CLONE_RESULT )
 


### PR DESCRIPTION
Disable submodule cloning of Unity and CBMC submodules with the `git submodule update` command to improve cloning experience of the `aws/aws-iot-device-sdk-for-embedded-c` repository that submodules this repository. The pupose is to avoid duplicate cloning of leaf submodules from multiple repositories submoduled by C-SDK