### PR TITLE
Update doxygen memory estimates and GCC toolchain link

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -17,7 +17,7 @@ AWS IoT Device Defender lets you continuously monitor security metrics from devi
 
 <table>
     <tr>
-        <td colspan="4"><center><b>Code size of AWS IoT Device Defender Client Library files (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/9-2019-q4-major))</b></center></td>
+        <td colspan="4"><center><b>Code size of AWS IoT Device Defender Client Library files (sizes generated with [GCC for ARM Cortex-M toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/9-2020-q2-update))</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>
@@ -27,9 +27,9 @@ AWS IoT Device Defender lets you continuously monitor security metrics from devi
     </tr>
     <tr>
         <td>defender.c</td>
-        <td>2.0K</td>
-        <td>1.1K</td>
-        <td>0.6K</td>
+        <td>3.1K</td>
+        <td>1.2K</td>
+        <td>0.9K</td>
     </tr>
 </table>
  */


### PR DESCRIPTION
*Description of changes:* Updating library memory estimates and GCC toolchain download link, to point to the latest release. The README update to link to the memory estimates doxygen page will be in a separate PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
