### PR TITLE
Add README.md link to memory estimates doxygen page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Deviations from the MISRA C:2012 guidelines are documented under [MISRA Deviatio
 This library has also undergone static code analysis using [Coverity static analysis](https://scan.coverity.com/),
 and validation of memory safety through the [CBMC automated reasoning tool](https://www.cprover.org/cbmc/).
 
+See memory requirements for this library [here](https://docs.aws.amazon.com/embedded-csdk/202011.00/lib-ref/libraries/aws/device-defender-for-aws-iot-embedded-sdk/docs/doxygen/output/html/index.html#defender_memory_requirements).
+
 ## AWS IoT Device Defender Client Config File
 
 The AWS IoT Device Defender Client Library exposes build configuration macros


### PR DESCRIPTION
*Description of changes:* Adding link in README to point to the library-specific doxygen page for memory estimates. Draft until doxygen links are live.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
