### PR TITLE
Add custom metrics macros

### DIFF
--- a/source/include/defender.h
+++ b/source/include/defender.h
@@ -600,6 +600,66 @@ typedef enum
  */
 #define DEFENDER_REPORT_LENGTH_PKS_OUT_KEY                    STRING_LITERAL_LENGTH( DEFENDER_REPORT_LENGTH_PKS_OUT_KEY )
 
+/**
+ * @ingroup defender_constants
+ * @brief "custom_metrics" key in the defender report.
+ */
+#define DEFENDER_REPORT_CUSTOM_METRICS_KEY                    DEFENDER_REPORT_SELECT_KEY( "custom_metrics", "cmet" )
+
+/**
+ * @ingroup defender_constants
+ * @brief Length of the "custom_metrics" key in the defender report.
+ */
+#define DEFENDER_REPORT_LENGTH_CUSTOM_METRICS_KEY             STRING_LITERAL_LENGTH( DEFENDER_REPORT_LENGTH_CUSTOM_METRICS_KEY )
+
+/**
+ * @ingroup defender_constants
+ * @brief "number" key in the defender report.
+ */
+#define DEFENDER_REPORT_NUMBER_KEY                            "number"
+
+/**
+ * @ingroup defender_constants
+ * @brief Length of the "number" key in the defender report.
+ */
+#define DEFENDER_REPORT_LENGTH_NUMBER_KEY                     STRING_LITERAL_LENGTH( DEFENDER_REPORT_LENGTH_NUMBER_KEY )
+
+/**
+ * @ingroup defender_constants
+ * @brief "number_list" key in the defender report.
+ */
+#define DEFENDER_REPORT_NUMBER_LIST_KEY                       "number_list"
+
+/**
+ * @ingroup defender_constants
+ * @brief Length of the "number_list" key in the defender report.
+ */
+#define DEFENDER_REPORT_LENGTH_NUMBER_LIST_KEY                STRING_LITERAL_LENGTH( DEFENDER_REPORT_LENGTH_NUMBER_LIST_KEY )
+
+/**
+ * @ingroup defender_constants
+ * @brief "string_list" key in the defender report.
+ */
+#define DEFENDER_REPORT_STRING_LIST_KEY                       "string_list"
+
+/**
+ * @ingroup defender_constants
+ * @brief Length of the "string_list" key in the defender report.
+ */
+#define DEFENDER_REPORT_LENGTH_STRING_LIST_KEY                STRING_LITERAL_LENGTH( DEFENDER_REPORT_LENGTH_STRING_LIST_KEY )
+
+/**
+ * @ingroup defender_constants
+ * @brief "ip_list" key in the defender report.
+ */
+#define DEFENDER_REPORT_IP_LIST_KEY                           "ip_list"
+
+/**
+ * @ingroup defender_constants
+ * @brief Length of the "ip_list" key in the defender report.
+ */
+#define DEFENDER_REPORT_LENGTH_IP_LIST_KEY                    STRING_LITERAL_LENGTH( DEFENDER_REPORT_LENGTH_IP_LIST_KEY )
+
 /*-----------------------------------------------------------*/
 
 /**


### PR DESCRIPTION
Adds macros for the keys used to include custom metrics in device defender reports. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
