### PR TITLE
Removed parentheses for DEFENDER_REPORT_SELECT_KEY macro

### DIFF
--- a/source/include/defender.h
+++ b/source/include/defender.h
@@ -341,9 +341,9 @@ typedef enum
 
 /* Keys used in defender report. */
 #if ( defined( DEFENDER_USE_LONG_KEYS ) && ( DEFENDER_USE_LONG_KEYS == 1 ) )
-    #define DEFENDER_REPORT_SELECT_KEY( longKey, shortKey )    ( longKey )
+    #define DEFENDER_REPORT_SELECT_KEY( longKey, shortKey )    longKey
 #else
-    #define DEFENDER_REPORT_SELECT_KEY( longKey, shortKey )    ( shortKey )
+    #define DEFENDER_REPORT_SELECT_KEY( longKey, shortKey )    shortKey
 #endif
 
 /** @endcond */


### PR DESCRIPTION
Removed parentheses for DEFENDER_REPORT_SELECT_KEY macro so that it can be used with other strings for build time string concatenation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
