### PR TITLE
Update broken MISRA link

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -1,7 +1,7 @@
 # MISRA Compliance
 
 The Device Defender Client Library files conform to the
-[MISRA C:2012](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx)
+[MISRA C:2012](https://www.misra.org.uk)
 guidelines, with some noted exceptions. Compliance is checked with Coverity static analysis.
 Deviations from the MISRA standard are listed below:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library is distributed under the [MIT Open Source License](LICENSE).
 This library has gone through code quality checks including verification that no
 function has a [GNU Complexity](https://www.gnu.org/software/complexity/manual/complexity.html)
 score over 8, and checks against deviations from mandatory rules in the
-[MISRA coding standard](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx).
+[MISRA coding standard](https://www.misra.org.uk).
 Deviations from the MISRA C:2012 guidelines are documented under [MISRA Deviations](MISRA.md).
 This library has also undergone static code analysis using [Coverity static analysis](https://scan.coverity.com/),
 and validation of memory safety through the [CBMC automated reasoning tool](https://www.cprover.org/cbmc/).


### PR DESCRIPTION
Because the MISRA website was updated, an older link is no longer valid. Update the link so that it just points to the domain to avoid this from happening again.