### PR TITLE
Enable logging macros in CI checks for Device Defender

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,18 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
         with:
           path: ./build/coverage.info
+  build-with-default-config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone This Repo
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DDEFENDER_DO_NOT_USE_CUSTOM_CONFIG'
+          make -C build/ all
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,11 +40,11 @@ include( ${MODULE_ROOT_DIR}/defenderFilePaths.cmake )
 add_library( coverity_analysis
              ${DEFENDER_SOURCES} )
 
-# Build Device Defender library without requiring config file.
-target_compile_definitions( coverity_analysis PUBLIC DEFENDER_DO_NOT_USE_CUSTOM_CONFIG=1 )
-
 # Device Defender public include path.
-target_include_directories( coverity_analysis PUBLIC ${DEFENDER_INCLUDE_PUBLIC_DIRS} )
+target_include_directories( coverity_analysis
+                            PUBLIC
+                            ${DEFENDER_INCLUDE_PUBLIC_DIRS}
+                            "${CMAKE_CURRENT_LIST_DIR}/include" )
 
 #  ============================  Test Configuration ============================
 

--- a/test/cbmc/proofs/Makefile-project-defines
+++ b/test/cbmc/proofs/Makefile-project-defines
@@ -41,10 +41,11 @@ COMPILE_FLAGS += -std=gnu90
 INCLUDES += -I$(SRCDIR)/test/cbmc/include
 INCLUDES += -I$(SRCDIR)/source/include
 INCLUDES += -I$(SRCDIR)/source
+INCLUDES += -I$(SRCDIR)/test/include
 
 # Preprocessor definitions -D...
 DEFINES += -Ddefender_EXPORTS
-DEFINES += -DDEFENDER_DO_NOT_USE_CUSTOM_CONFIG
+# DEFINES += -DDEFENDER_DO_NOT_USE_CUSTOM_CONFIG
 
 # Path to arpa executable
 # ARPA =

--- a/test/cbmc/proofs/Makefile-project-defines
+++ b/test/cbmc/proofs/Makefile-project-defines
@@ -45,7 +45,6 @@ INCLUDES += -I$(SRCDIR)/test/include
 
 # Preprocessor definitions -D...
 DEFINES += -Ddefender_EXPORTS
-# DEFINES += -DDEFENDER_DO_NOT_USE_CUSTOM_CONFIG
 
 # Path to arpa executable
 # ARPA =

--- a/test/include/defender_config.h
+++ b/test/include/defender_config.h
@@ -1,0 +1,41 @@
+/*
+ * AWS IoT Device Defender Client v1.1.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file defender_config.h
+ * @brief Config values for testing the AWS IoT Device Defender Client Library.
+ */
+
+#ifndef DEFENDER_CONFIG_H_
+#define DEFENDER_CONFIG_H_
+
+#include <stdio.h>
+
+#define LogError( message )    printf( "Error: " ); printf message; printf( "\n" )
+
+#define LogWarn( message )     printf( "Warn: " ); printf message; printf( "\n" )
+
+#define LogInfo( message )     printf( "Info: " ); printf message; printf( "\n" )
+
+#define LogDebug( message )    printf( "Debug: " ); printf message; printf( "\n" )
+
+#endif /* DEFENDER_CONFIG_H_ */

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -13,15 +13,13 @@ list( APPEND library_source_files
 
 # List of library include directories.
 list( APPEND library_include_directories
-      ${DEFENDER_INCLUDE_PUBLIC_DIRS} )
+      ${DEFENDER_INCLUDE_PUBLIC_DIRS}
+      "${CMAKE_CURRENT_LIST_DIR}/../include" )
 
 # Create a target for building library.
 create_library_target( ${library_target_name}
                        "${library_source_files}"
                        "${library_include_directories}" )
-
-# Build Device Defender library without requiring config file.
-target_compile_definitions( ${library_target_name} PUBLIC DEFENDER_DO_NOT_USE_CUSTOM_CONFIG=1 )
 
 # =========================== Test Binary ==============================
 


### PR DESCRIPTION
Fix all unit testing and CBMC to use a custom config that enables logging and tests using printf. Adds a new CI check to ensure DO_NOT_USE_CUSTOM_CONFIG builds still are tested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.